### PR TITLE
remove questionable matrix warning

### DIFF
--- a/src/data/alternatives.ts
+++ b/src/data/alternatives.ts
@@ -306,7 +306,6 @@ export const alternatives: Alternative[] = [
 		originNote:
 			'Matrix is a protocol run by many independent homeservers, so "origin" matters less than the server you pick.',
 		warnings: [
-			'Matrix.org has questionable past more info here: https://hackea.org/notas/matrix.html',
 			'E2EE hides content, but homeservers see metadata (who/when).',
 			'Client-dependent experience: Element most complete (but UI differs from Discord, screenshare lacks audio); Commet more Discord-like (single maintainer, worse screenshare framerates/no audio).',
 		],


### PR DESCRIPTION
How much stock do you put in [the article I'm proposing to remove](https://hackea.org/notas/matrix.html)? The first part reads like a conspiracy theory (I can't count the number of open source projects that forked off from internal corporate origins). I've personally never heard of the group that posted it before. They also make sweeping claims without providing sweeping evidence, e.g.

> However, many Free Software activists refuse to use it.

The discussion in [this gist linked from the article](https://gist.github.com/maxidorius/5736fd09c9194b7a6dc03b6b8d7220d0) is 7 years out of date and does not read like a good faith review from the reviewer to me.

I think the largest security hole is already covered by the following (entirely accurate) point:

```
E2EE hides content, but homeservers see metadata (who/when).
```

The metadata in question (things that aren't E2EE) include:

- Room topic
- Message timestamps
- User names, user nicknames, user avatars
- Reactions (e.g. emoji) to messages

There are also additional actions that a malicious homeserver admin could take to compromise things about your account. But this. in particular, is true about the vast majority of alternatives currently listed here.

I just don't think the reference to this site will be useful to those searching for alternatives. If anyone visits the link, the most likely outcome is they read "Israel intelligence" and then give up completely, even though Matrix would already be a giant leap forward compared to Discord in terms of open source, encryption, and decentralization. (I don't pretend it's the best in terms of security/privacy though; Session beats Matrix in that context, hands down.)